### PR TITLE
Fix init.d script in ubuntu

### DIFF
--- a/etc/ubuntu/init.d/maxscale.in
+++ b/etc/ubuntu/init.d/maxscale.in
@@ -45,7 +45,7 @@ _RETVAL_STATUS_NOT_RUNNING=3
 #################################
 NAME=maxscale
 DAEMON=@CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale
-DAEMON_OPTS= --user=maxscale
+DAEMON_OPTS=' --user=maxscale'
 # Source function library.
 . /lib/lsb/init-functions
 


### PR DESCRIPTION
Fix "/etc/init.d/maxscale: line 48: --user=maxscale: command not found" problem while using script from debian package (ubuntu 14.04).